### PR TITLE
chore: Require servr >= 0.32

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,6 +34,7 @@ Imports:
     progress,
     quarto,
     rmarkdown,
+    servr (>= 0.32),
     withr,
     xaringan,
     zip


### PR DESCRIPTION
Avoids issues with favicon 404 responses blocking `to_pdf()` and fixes #82.